### PR TITLE
use the full variable syntax

### DIFF
--- a/tasks/configure-plugins.yml
+++ b/tasks/configure-plugins.yml
@@ -20,7 +20,7 @@
     src: "{{ item }}.conf"
     dest: "{{ stackdriver_collectd_config_dir }}/{{ item }}.conf"
     validate: "{{ stackdriver_collectd_binary }} -tC %s"
-  with_items: stackdriver_enabled_plugins
+  with_items: '{{ stackdriver_enabled_plugins }}'
   when: item != ""
   notify:
     - restart collectd
@@ -33,7 +33,7 @@
 
 - name: Remove unmanaged files if requested.
   file: path={{ stackdriver_collectd_config_dir }}/{{ item }} state=absent
-  with_items: contents.stdout_lines
+  with_items: '{{ contents.stdout_lines }}'
   when: >
     stackdriver_remove_unmanaged and (
       not (item.endswith('.conf') and item != '.conf') or


### PR DESCRIPTION
Remove deprecation warnings stating that Using bare variables is
deprecated.