### PR TITLE
Add suppport for monitoring third-party applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,43 @@ Compute Engine instances created without the default credentials, then you must
 complete the following steps
 https://cloud.google.com/monitoring/agent/authorization#before_you_begin
 
+Role Variables
+--------------
+
+By default, no plugins are enabled, in which case the agent will only monitor
+certain system resources. (Moreover, all of the following variables are ignored
+when deploying to Windows.)
+
+Each plugin is enabled using a variable like `<plugin>_enabled` --
+e.g., `apache_enabled` -- where the default value is `no`.
+
+For many of the plugins, simply enabling the plugin may suffice in simple cases.
+In particular, please note that specifying a host to monitor other than
+`localhost` is atypical, as the Cloud Ops monitoring service assumes that the
+data sent by the agent pertains to the host on which the agent is running.
+
+The following plugins are currently supported:
+- Apache
+- JVM Monitoring
+- Memcached
+- Mysql
+- Nginx
+- Redis
+- StatsD
+
+For more information please see [Monitoring third-party applications](https://cloud.google.com/monitoring/agent/plugins).
+
+### Other variables
+
+Setting the following variable to `yes` will cause existing configuration files
+for disabled plugins to be removed. In that case, the role will not be additive,
+and applying it more than once to the same host (perhaps because the host is in
+multiple groups) is likely to yield surprising results.
+
+```
+remove_unmanaged: no
+```
+
 Example Playbook
 ----------------
 
@@ -30,6 +67,7 @@ Example Playbook
     - role: cloud_ops
       vars:
         agent_type: "monitoring"
+        apache_enabled: yes
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,129 @@ package_state: "present"
 # default vars for the monitoring agent
 monitoring_package_name: stackdriver-agent
 monitoring_service_name: stackdriver-agent
+
+collectd_binary: /opt/stackdriver/collectd/sbin/stackdriver-collectd
+collectd_config_dir: /opt/stackdriver/collectd/etc/collectd.d/managed
+
+# If you define a new plugin template, please add it here. Although a list of
+# just the names of the enabled plugins would be nicer to work with, we manage
+# with a list in which disabled plugins evaluate to empty strings.
+enabled_plugins:
+  - "{% if apache_enabled %}apache{% endif %}"
+  - "{% if cassandra-22_enabled %}cassandra-22{% endif %}"
+  - "{% if cassandra_enabled %}cassandra{% endif %}"
+  - "{% if hbase-098_enabled %}hbase-098{% endif %}"
+  - "{% if hbase-098-standalone_enabled %}hbase-098-standalone{% endif %}"
+  - "{% if hbase-095_enabled %}hbase-095{% endif %}"
+  - "{% if jvm-sun-hotspot_enabled %}jvm-sun-hotspot{% endif %}"
+  - "{% if kafka-082_enabled %}kafka-082{% endif %}"
+  - "{% if memcached_enabled %}memcached{% endif %}"
+  - "{% if mysql_enabled %}mysql{% endif %}"
+  - "{% if nginx_enabled %}nginx{% endif %}"
+  - "{% if redis_enabled %}redis{% endif %}"
+  - "{% if statsd_enabled %}redis{% endif %}"
+  - "{% if tomcat-7_enabled %}tomcat-7{% endif %}"
+
+remove_unmanaged: no
+
+# default vars for third party plugins
+### apache
+
+apache_enabled: no
+apache_name: localhost
+apache_host: local-stackdriver-agent.stackdriver.com
+apache_port: 80
+apache_status_url: "http://{{ apache_host }}:{{ apache_port }}/server-status?auto"
+
+### cassandra 2.2.x
+
+cassandra-22_enabled: no
+cassandra-22_host: localhost
+cassandra-22_port: 7199
+cassandra-22_service_url: "service:jmx:rmi:///jndi/rmi://{{ cassandra-22_host }}:{{ cassandra-22_port }}/jmxrmi"
+
+### cassandra <=2.1.x
+
+cassandra_enabled: no
+cassandra_host: localhost
+cassandra_port: 7199
+cassandra_service_url: "service:jmx:rmi:///jndi/rmi://{{ cassandra_host }}:{{ cassandra_port }}/jmxrmi"
+
+### hbase 0.98+
+
+hbase-098_enabled: no
+hbase-098_host: localhost
+hbase-098_master_port: 10101
+hbase-098_regionserver_port: 10102
+
+### hbase 0.98+ standalone
+
+hbase-098-standalone_enabled: no
+hbase-098-standalone_host: localhost
+hbase-098-standalone_port: 10101
+hbase-098-standalone_service_url: "service:jmx:rmi:///jndi/rmi://{{ hbase-098-standalone_host }}:{{ hbase-098-standalone_port ))/jmxrmi"
+
+### hbase <=.95
+
+hbase-095_enabled: no
+hbase-095_host: localhost
+hbase-095_regionserver_port: 10102
+hbase-095_service_url: "service:jmx:rmi:///jndi/rmi://{{ hbase-095_host }}:{{ hbase-095_regionserver_port ))/jmxrmi"
+
+### jvm-sun-hotspot
+
+jvm-sun-hotspot_enabled: no
+jmx_host: localhost
+jmx_port: ""
+jmx_service_url: "service:jmx:rmi:///jndi/rmi://{{ jmx_host }}:{{ jmx_port }}/jmxrmi"
+
+### kafka 0.8.2+
+
+kafka-082_enabled: no
+kafka-082_host: localhost
+kafka-082_port: 9999
+kafka-082_service_url: "service:jmx:rmi:///jndi/rmi://{{ kafka-082_host }}:{{ kafka-082_port }}/jmxrmi"
+
+### memcached
+
+memcached_enabled: no
+memcached_host: localhost
+memcached_port: 11211
+
+### mysql
+
+mysql_enabled: no
+mysql_database_name: default
+mysql_host: localhost
+mysql_port: 3306
+mysql_user: root
+mysql_pass: ""
+
+### nginx
+
+nginx_enabled: no
+nginx_host: local-stackdriver-agent.stackdriver.com
+nginx_port: 80
+nginx_status_url: "http://{{ nginx_host }}:{{ nginx_port }}/nginx_status"
+
+### redis
+
+redis_enabled: no
+redis_host: localhost
+redis_port: 6379
+redis_name: "{{ redis_host }}_{{ redis_port }}"
+redis_timeout: 2000     # Seconds
+redis_pass: ""
+
+### statsd
+
+statsd_enabled: no
+statsd_host: localhost
+statsd_port: 8125
+
+### tomcat <=7.x
+
+tomcat-7_enabled: no
+tomcat-7_host: localhost
+tomcat-7_port: 0912
+tomcat-7_service_url: "service:jmx:rmi:///jndi/rmi://{{ tomcat-7_port }}:{{ tomcat-7_port }}/jmxrmi"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -24,3 +24,34 @@
     name: "{{ monitoring_package_name }}"
     state: "{{ package_state }}"
 #TODO(rmoriar1): Clean up the repo when package_state is absent.
+
+- name: Ensure the collectd configuration directory exists
+  file:
+    path: "{{ collectd_config_dir }}"
+    state: directory
+
+- name: Render the configuration directory from templates
+  template:
+    src: "{{ item }}.conf"
+    dest: "{{ collectd_config_dir }}/{{ item }}.conf"
+    validate: "{{ collectd_binary }} - tC %s"
+  with_items: "{{ enabled_plugins }}"
+  when: item
+  notify: restart monitoring agent
+
+- name: List the contents of the configuration directory.
+  command:
+    cmd: "ls -1 {{ collectd_config_dir }}"
+  changed_when: False
+  register: contents
+
+- name: Remove unmanaged files if requested.
+  file:
+    path: "{{ collectd_config_dir }}/{{ item }}"
+    state: absent
+  with_items: '{{ contents.stdout_lines }}'
+  when: >
+    remove_unmanaged and (
+      not (item.endswith('.conf') and item != '.conf') or
+      item.rsplit('.', 1)[0] not in enabled_plugins)
+  notify: restart monitoring agent

--- a/templates/apache.conf
+++ b/templates/apache.conf
@@ -1,0 +1,10 @@
+# This is the monitoring configuration for the Apache web server.
+# Make sure mod_status is enabled in your Apache configuration.
+# Look for apache_host and apache_port to adjust your configuration file.
+LoadPlugin apache
+<Plugin "apache">
+  <Instance "{{ apache_name }}">
+    URL "{{ apache_status_url }}"
+  </Instance>
+{% endfor %}
+</Plugin>

--- a/templates/cassandra-22.conf
+++ b/templates/cassandra-22.conf
@@ -1,0 +1,940 @@
+# This is the monitoring configuration for Cassandra 2.2.x.
+# Look for cassandra-22_host and cassandra-22_port to adjust your configuration file.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "cassandra_storageservice-load">
+            ObjectName "org.apache.cassandra.metrics:type=Storage,name=Load"
+            <Value>
+                Type "gauge"
+                InstancePrefix "storage_service-load"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_storageservice-exceptions">
+            ObjectName "org.apache.cassandra.metrics:type=Storage,name=Exceptions"
+            <Value>
+                Type "counter"
+                InstancePrefix "storage_service-exception_count"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_commitlog-pending">
+            ObjectName "org.apache.cassandra.metrics:type=CommitLog,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "commitlog-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_commitlog-completed">
+            ObjectName "org.apache.cassandra.metrics:type=CommitLog,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "commitlog-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_commitlog-totalsize">
+            ObjectName "org.apache.cassandra.metrics:type=CommitLog,name=TotalCommitLogSize"
+            <Value>
+                Type "gauge"
+                InstancePrefix "commitlog-total_size"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_compactionmanager-pending">
+            ObjectName "org.apache.cassandra.metrics:type=Compaction,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "compaction_manager-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_compactionmanager-completed">
+            ObjectName "org.apache.cassandra.metrics:type=Compaction,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "compaction_manager-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_MutationStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "mutation_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_MutationStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "mutation_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_MutationStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "mutation_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_MutationStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=MutationStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "mutation_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_ReadRepairStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_repair_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_ReadRepairStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_repair_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_ReadRepairStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_repair_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_ReadRepairStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadRepairStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "read_repair_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_ReadStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_ReadStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_ReadStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_ReadStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=ReadStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "read_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_RequestResponseStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "request_response_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_RequestResponseStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "request_response_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_RequestResponseStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "request_response_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_stage_RequestResponseStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=request,scope=RequestResponseStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "request_response_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_AntiEntropySessions-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropySessions,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_sessions-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_AntiEntropySessions-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropySessions,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_sessions-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_AntiEntropySessions-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropySessions,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_sessions-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_AntiEntropySessions-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropySessions,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "anti_entropy_sessions-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_AntiEntropyStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_AntiEntropyStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_AntiEntropyStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_AntiEntropyStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=AntiEntropyStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "anti_entropy_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_FlushWriter-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "flush_writer-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_FlushWriter-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "flush_writer-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_FlushWriter-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "flush_writer-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_FlushWriter-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtableFlushWriter,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "flush_writer-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_GossipStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "gossip_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_GossipStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "gossip_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_GossipStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "gossip_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_GossipStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=GossipStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "gossip_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_HintedHandoff-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=HintedHandoff,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "hinted_handoff-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_HintedHandoff-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=HintedHandoff,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "hinted_handoff-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_HintedHandoff-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=HintedHandoff,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "hinted_handoff-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_HintedHandoff-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=HintedHandoff,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "hinted_handoff-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_InternalResponseStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=InternalResponseStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "internal_response_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_InternalResponseStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=InternalResponseStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "internal_response_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_InternalResponseStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=InternalResponseStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "internal_response_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_InternalResponseStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=InternalResponseStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "internal_response_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_MemtablePostFlusher-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "memtable_post_flusher-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MemtablePostFlusher-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "memtable_post_flusher-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MemtablePostFlusher-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "memtable_post_flusher-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MemtablePostFlusher-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MemtablePostFlush,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "memtable_post_flusher-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_MigrationStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "migration_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MigrationStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "migration_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MigrationStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "migration_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MigrationStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MigrationStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "migration_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_MiscStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "misc_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MiscStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "misc_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MiscStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "misc_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_MiscStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=MiscStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "misc_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_StreamStage-active">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=StreamStage,name=ActiveTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "stream_stage-active_count"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_StreamStage-blocked">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=StreamStage,name=CurrentlyBlockedTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "stream_stage-currently_blocked_tasks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_StreamStage-pending">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=StreamStage,name=PendingTasks"
+            <Value>
+                Type "gauge"
+                InstancePrefix "stream_stage-pending_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_internal_StreamStage-completed">
+            ObjectName "org.apache.cassandra.metrics:type=ThreadPools,path=internal,scope=StreamStage,name=CompletedTasks"
+            <Value>
+                Type "counter"
+                InstancePrefix "stream_stage-completed_tasks"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_Cache_KeyCache-Hits">
+            ObjectName "org.apache.cassandra.metrics:type=Cache,scope=KeyCache,name=Hits"
+            <Value>
+                Type "gauge"
+                InstancePrefix "cache_key_cache-hits"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ClientRequest_Read-Latency">
+            ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Latency"
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-max"
+                Table false
+                Attribute "Max"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-99p"
+                Table false
+                Attribute "99thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-95p"
+                Table false
+                Attribute "95thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_read-latency-50p"
+                Table false
+                Attribute "50thPercentile"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ClientRequest_Write-Latency">
+            ObjectName "org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=Latency"
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-max"
+                Table false
+                Attribute "Max"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-99p"
+                Table false
+                Attribute "99thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-95p"
+                Table false
+                Attribute "95thPercentile"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "client_request_write-latency-50p"
+                Table false
+                Attribute "50thPercentile"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ColumnFamily-MaxRowSize">
+            ObjectName "org.apache.cassandra.metrics:type=ColumnFamily,name=MaxRowSize"
+            <Value>
+                Type "gauge"
+                InstancePrefix "column_family-max_row_size"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_ColumnFamily-CompressionRatio">
+            ObjectName "org.apache.cassandra.metrics:type=ColumnFamily,name=CompressionRatio"
+            <Value>
+                Type "gauge"
+                InstancePrefix "column_family-compression_ratio"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "cassandra_DroppedMessage_MUTATION-Dropped">
+            ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=MUTATION,name=Dropped"
+            <Value>
+                Type "counter"
+                InstancePrefix "dropped_message_mutation-dropped-count"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "cassandra_DroppedMessage_READ-Dropped">
+            ObjectName "org.apache.cassandra.metrics:type=DroppedMessage,scope=READ,name=Dropped"
+            <Value>
+                Type "counter"
+                InstancePrefix "dropped_message_read-dropped-count"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+
+
+        <Connection>
+            ServiceURL "{{ cassandra-22_service_url }}"
+
+            Collect "cassandra_storageservice-load"
+            Collect "cassandra_storageservice-exceptions"
+            Collect "cassandra_commitlog-pending"
+            Collect "cassandra_commitlog-completed"
+            Collect "cassandra_commitlog-totalsize"
+            Collect "cassandra_compactionmanager-pending"
+            Collect "cassandra_compactionmanager-completed"
+            Collect "cassandra_stage_MutationStage-active"
+            Collect "cassandra_stage_MutationStage-blocked"
+            Collect "cassandra_stage_MutationStage-pending"
+            Collect "cassandra_stage_MutationStage-completed"
+            Collect "cassandra_stage_ReadRepairStage-active"
+            Collect "cassandra_stage_ReadRepairStage-blocked"
+            Collect "cassandra_stage_ReadRepairStage-pending"
+            Collect "cassandra_stage_ReadRepairStage-completed"
+            Collect "cassandra_stage_ReadStage-active"
+            Collect "cassandra_stage_ReadStage-blocked"
+            Collect "cassandra_stage_ReadStage-pending"
+            Collect "cassandra_stage_ReadStage-completed"
+            Collect "cassandra_stage_RequestResponseStage-active"
+            Collect "cassandra_stage_RequestResponseStage-blocked"
+            Collect "cassandra_stage_RequestResponseStage-pending"
+            Collect "cassandra_stage_RequestResponseStage-completed"
+            Collect "cassandra_internal_AntiEntropySessions-active"
+            Collect "cassandra_internal_AntiEntropySessions-blocked"
+            Collect "cassandra_internal_AntiEntropySessions-pending"
+            Collect "cassandra_internal_AntiEntropySessions-completed"
+            Collect "cassandra_internal_AntiEntropyStage-active"
+            Collect "cassandra_internal_AntiEntropyStage-blocked"
+            Collect "cassandra_internal_AntiEntropyStage-pending"
+            Collect "cassandra_internal_AntiEntropyStage-completed"
+            Collect "cassandra_internal_FlushWriter-active"
+            Collect "cassandra_internal_FlushWriter-blocked"
+            Collect "cassandra_internal_FlushWriter-pending"
+            Collect "cassandra_internal_FlushWriter-completed"
+            Collect "cassandra_internal_GossipStage-active"
+            Collect "cassandra_internal_GossipStage-blocked"
+            Collect "cassandra_internal_GossipStage-pending"
+            Collect "cassandra_internal_GossipStage-completed"
+            Collect "cassandra_internal_HintedHandoff-active"
+            Collect "cassandra_internal_HintedHandoff-blocked"
+            Collect "cassandra_internal_HintedHandoff-pending"
+            Collect "cassandra_internal_HintedHandoff-completed"
+            Collect "cassandra_internal_InternalResponseStage-active"
+            Collect "cassandra_internal_InternalResponseStage-blocked"
+            Collect "cassandra_internal_InternalResponseStage-pending"
+            Collect "cassandra_internal_InternalResponseStage-completed"
+            Collect "cassandra_internal_MemtablePostFlusher-active"
+            Collect "cassandra_internal_MemtablePostFlusher-blocked"
+            Collect "cassandra_internal_MemtablePostFlusher-pending"
+            Collect "cassandra_internal_MemtablePostFlusher-completed"
+            Collect "cassandra_internal_MigrationStage-active"
+            Collect "cassandra_internal_MigrationStage-blocked"
+            Collect "cassandra_internal_MigrationStage-pending"
+            Collect "cassandra_internal_MigrationStage-completed"
+            Collect "cassandra_internal_MiscStage-active"
+            Collect "cassandra_internal_MiscStage-blocked"
+            Collect "cassandra_internal_MiscStage-pending"
+            Collect "cassandra_internal_MiscStage-completed"
+            Collect "cassandra_internal_StreamStage-active"
+            Collect "cassandra_internal_StreamStage-blocked"
+            Collect "cassandra_internal_StreamStage-pending"
+            Collect "cassandra_internal_StreamStage-completed"
+            Collect "cassandra_Cache_KeyCache-Hits"
+            Collect "cassandra_ClientRequest_Read-Latency"
+            Collect "cassandra_ClientRequest_Write-Latency"
+            Collect "cassandra_ColumnFamily-MaxRowSize"
+            Collect "cassandra_ColumnFamily-CompressionRatio"
+            Collect "cassandra_DroppedMessage_MUTATION-Dropped"
+            Collect "cassandra_DroppedMessage_READ-Dropped"
+        </Connection>
+
+
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "{{ cassandra-22_service_url }}"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+<Chain "GenericJMX_cassandra">
+    <Rule "rewrite_genericjmx_to_cassandra">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^cassandra.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "cassandra" ""
+        </Target>
+        <Target "set">
+            Plugin "cassandra"
+        </Target>
+    </Rule>
+    <Rule "go_back">
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_cassandra">
+        <Target "jump">
+            Chain "GenericJMX_cassandra"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"
+
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"

--- a/templates/cassandra.conf
+++ b/templates/cassandra.conf
@@ -1,0 +1,679 @@
+# This is the monitoring configuration for Cassandra 2.1.x and earlier.
+# Look for cassandra_host and cassandra_port to adjust your configuration file.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "cassandra_storageservice">
+            ObjectName "org.apache.cassandra.db:type=StorageService"
+            <Value>
+                Type "gauge"
+                InstancePrefix "storage_service-load"
+                Table false
+                Attribute "Load"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "storage_service-exception_count"
+                Table false
+                Attribute "ExceptionCount"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_commitlog">
+            ObjectName "org.apache.cassandra.db:type=Commitlog"
+            <Value>
+                Type "gauge"
+                InstancePrefix "commitlog-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "commitlog-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "commitlog-total_size"
+                Table false
+                Attribute "TotalCommitlogSize"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_compactionmanager">
+            ObjectName "org.apache.cassandra.db:type=CompactionManager"
+            <Value>
+                Type "gauge"
+                InstancePrefix "compaction_manager-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "compaction_manager-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_MutationStage">
+            ObjectName "org.apache.cassandra.request:type=MutationStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "mutation_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "mutation_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "mutation_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "mutation_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_ReadRepairStage">
+            ObjectName "org.apache.cassandra.request:type=ReadRepairStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_repair_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_repair_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_repair_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "read_repair_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_ReadStage">
+            ObjectName "org.apache.cassandra.request:type=ReadStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "read_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "read_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_ReplicateOnWriteStage">
+            ObjectName "org.apache.cassandra.request:type=ReplicateOnWriteStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "replicate_on_write_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "replicate_on_write_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "replicate_on_write_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "replicate_on_write_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_stage_RequestResponseStage">
+            ObjectName "org.apache.cassandra.request:type=RequestResponseStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "request_response_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "request_response_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "request_response_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "request_response_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_AntiEntropySessions">
+            ObjectName "org.apache.cassandra.internal:type=AntiEntropySessions"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_sessions-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_sessions-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_sessions-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "anti_entropy_sessions-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_AntiEntropyStage">
+            ObjectName "org.apache.cassandra.internal:type=AntiEntropyStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "anti_entropy_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "anti_entropy_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_FlushWriter">
+            ObjectName "org.apache.cassandra.internal:type=FlushWriter"
+            <Value>
+                Type "gauge"
+                InstancePrefix "flush_writer-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "flush_writer-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "flush_writer-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "flush_writer-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_GossipStage">
+            ObjectName "org.apache.cassandra.internal:type=GossipStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "gossip_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "gossip_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "gossip_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gossip_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_HintedHandoff">
+            ObjectName "org.apache.cassandra.internal:type=HintedHandoff"
+            <Value>
+                Type "gauge"
+                InstancePrefix "hinted_handoff-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "hinted_handoff-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "hinted_handoff-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "hinted_handoff-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_InternalResponseStage">
+            ObjectName "org.apache.cassandra.internal:type=InternalResponseStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "internal_response_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "internal_response_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "internal_response_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "internal_response_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_MemtablePostFlusher">
+            ObjectName "org.apache.cassandra.internal:type=MemtablePostFlusher"
+            <Value>
+                Type "gauge"
+                InstancePrefix "memtable_post_flusher-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "memtable_post_flusher-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "memtable_post_flusher-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "memtable_post_flusher-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_MigrationStage">
+            ObjectName "org.apache.cassandra.internal:type=MigrationStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "migration_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "migration_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "migration_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "migration_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_MiscStage">
+            ObjectName "org.apache.cassandra.internal:type=MiscStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "misc_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "misc_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "misc_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "misc_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+        <MBean "cassandra_internal_StreamStage">
+            ObjectName "org.apache.cassandra.internal:type=StreamStage"
+            <Value>
+                Type "gauge"
+                InstancePrefix "stream_stage-active_count"
+                Table false
+                Attribute "ActiveCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "stream_stage-currently_blocked_tasks"
+                Table false
+                Attribute "CurrentlyBlockedTasks"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "stream_stage-pending_tasks"
+                Table false
+                Attribute "PendingTasks"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "stream_stage-completed_tasks"
+                Table false
+                Attribute "CompletedTasks"
+            </Value>
+        </MBean>
+
+
+        <Connection>
+            ServiceURL "{{ cassandra_service_url }}"
+
+            Collect "cassandra_storageservice"
+            Collect "cassandra_commitlog"
+            Collect "cassandra_compactionmanager"
+            Collect "cassandra_stage_MutationStage"
+            Collect "cassandra_stage_ReadRepairStage"
+            Collect "cassandra_stage_ReadStage"
+            Collect "cassandra_stage_ReplicateOnWriteStage"
+            Collect "cassandra_stage_RequestResponseStage"
+            Collect "cassandra_internal_AntiEntropySessions"
+            Collect "cassandra_internal_AntiEntropyStage"
+            Collect "cassandra_internal_FlushWriter"
+            Collect "cassandra_internal_GossipStage"
+            Collect "cassandra_internal_HintedHandoff"
+            Collect "cassandra_internal_InternalResponseStage"
+            Collect "cassandra_internal_MemtablePostFlusher"
+            Collect "cassandra_internal_MigrationStage"
+            Collect "cassandra_internal_MiscStage"
+            Collect "cassandra_internal_StreamStage"
+        </Connection>
+
+
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "{{ cassandra_service_url }}"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+<Chain "GenericJMX_cassandra">
+    <Rule "rewrite_genericjmx_to_cassandra">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^cassandra.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "cassandra" ""
+        </Target>
+        <Target "set">
+            Plugin "cassandra"
+        </Target>
+    </Rule>
+    <Rule "go_back">
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_cassandra">
+        <Target "jump">
+            Chain "GenericJMX_cassandra"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"
+
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"

--- a/templates/hbase-095.conf
+++ b/templates/hbase-095.conf
@@ -1,0 +1,364 @@
+# This is the monitoring configuration for HBase 0.95 and earlier.
+# Look for hbase-095_host and hbase-095_regionserver_port to adjust your configuration file.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "hbase_regionserver_RegionServerStatistics">
+            ObjectName "hadoop:service=RegionServer,name=RegionServerStatistics"
+            # The three attributes below are identical; they are renamed versions of each other.
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheHitPercent"
+                Table false
+                # This may be a name that was never used.
+                Attribute "blockCacheExpressCachingRatio"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheHitPercent"
+                Table false
+                # This is the name used in HBase 0.94 and earlier.
+                Attribute "blockCacheHitCachingRatio"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheHitPercent"
+                Table false
+                Attribute "blockCountHitPercent"
+            </Value>
+
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-callQueueLength"
+                Table false
+                Attribute "callQueueLength"
+            </Value>
+
+            # The two attributes below are identical; one is a renamed version of the other.
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-compactionQueueLength"
+                Table false
+                # This is the name used in HBase 0.94 and earlier.
+                Attribute "compactionQueueSize"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-compactionQueueLength"
+                Table false
+                Attribute "compactionQueueLength"
+            </Value>
+
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-flushQueueLength"
+                Table false
+                Attribute "flushQueueSize"
+            </Value>
+
+            <Value>
+                Type "gauge"
+                # Renamed for consistency with newer metrics.
+                InstancePrefix "regionserver-memStoreSizeMB"
+                Table false
+                Attribute "memstoreSizeMB"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-numberOfOnlineRegions"
+                Table false
+                Attribute "numberOfOnlineRegions"
+            </Value>
+            <Value>
+                Type "counter"
+                # Renamed for consistency with newer metrics.
+                InstancePrefix "regionserver-readRequestCount"
+                Table false
+                Attribute "readRequestsCount"
+            </Value>
+            <Value>
+                Type "counter"
+                # Renamed for consistency with newer metrics.
+                InstancePrefix "regionserver-writeRequestCount"
+                Table false
+                Attribute "writeRequestsCount"
+            </Value>
+            <Value>
+                Type "counter"
+                # Renamed for consistency with newer metrics.
+                InstancePrefix "regionserver-slowAppendCount"
+                Table false
+                Attribute "slowHLogAppendCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-usedHeapMB"
+                Table false
+                Attribute "usedHeapMB"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheCount"
+                Table false
+                Attribute "blockCacheCount"
+            </Value>
+
+            # The two attributes below are identical; one is a renamed version of the other.
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheEvictedCount"
+                Table false
+                # This is the name used in HBase 0.94 and earlier.
+                Attribute "blockCacheEvictedCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheEvictionCount"
+                Table false
+                Attribute "blockCacheEvictionCount"
+            </Value>
+
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheFreeMB"
+                Table false
+                Attribute "blockCacheFreeMB"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheHitCount"
+                Table false
+                Attribute "blockCacheHitCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheMissCount"
+                Table false
+                Attribute "blockCacheMissCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheSizeMB"
+                Table false
+                Attribute "blockCacheSizeMB"
+            </Value>
+            <Value>
+                Type "gauge"
+                # Renamed for consistency with newer metrics.
+                InstancePrefix "regionserver-storeCount"
+                Table false
+                Attribute "NumberOfStores"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-NumberOfStorefiles"
+                Table false
+                Attribute "NumberOfStorefiles"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-requestsPerSecond"
+                Table false
+                Attribute "requestsPerSecond"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-storeFileIndexSizeMB"
+                Table false
+                Attribute "storeFileIndexSizeMB"
+            </Value>
+        </MBean>
+
+
+        <Connection>
+            ServiceURL "{{ hbase-095_service_url }}"
+        </Connection>
+
+
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "{{ hbase-095_service_url }}"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+LoadPlugin target_scale
+<Chain "GenericJMX_hbase">
+    <Rule "rewrite_genericjmx_to_hbase">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^hbase.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "hbase" ""
+        </Target>
+        <Target "set">
+            Plugin "hbase"
+        </Target>
+    </Rule>
+    <Rule "scale_old_size_metrics">
+        <Match regex>
+            TypeInstance "^.*MB$"
+        </Match>
+        <Target "scale">
+            Factor 1048576  # 1024 * 1024
+        </Target>
+        <Target "replace">
+            TypeInstance "MB" ""
+        </Target>
+    </Rule>
+    <Rule "go_back">
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_hbase">
+        <Target "jump">
+            Chain "GenericJMX_hbase"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"
+
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"

--- a/templates/hbase-098-standalone.conf
+++ b/templates/hbase-098-standalone.conf
@@ -1,0 +1,369 @@
+# This is the monitoring configuration for HBase 0.98 and later running in standalone mode
+# (all services on the same port).
+# Look for hbase-098-standalone_host and hbase-098-standalone_port to adjust your configuration file.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "hbase_master_Server">
+            ObjectName "Hadoop:service=HBase,name=Master,sub=Server"
+            <Value>
+                Type "gauge"
+                InstancePrefix "master-averageLoad"
+                Table false
+                Attribute "averageLoad"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "master-numRegionServers"
+                Table false
+                Attribute "numRegionServers"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "master-numDeadRegionServers"
+                Table false
+                Attribute "numDeadRegionServers"
+            </Value>
+        </MBean>
+
+        <MBean "hbase_ipc_IPC">
+            ObjectName "Hadoop:service=HBase,name=IPC,sub=IPC"
+            <Value>
+                Type "counter"
+                InstancePrefix "ipc-sentBytes"
+                Table false
+                Attribute "sentBytes"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "ipc-receivedBytes"
+                Table false
+                Attribute "receivedBytes"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "ipc-queueSize"
+                Table false
+                Attribute "queueSize"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "ipc-numOpenConnections"
+                Table false
+                Attribute "numOpenConnections"
+            </Value>
+        </MBean>
+
+        <MBean "hbase_regionserver_RegionServerStatistics">
+            ObjectName "Hadoop:service=HBase,name=RegionServer,sub=Server"
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheCount"
+                Table false
+                Attribute "blockCacheCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheEvictedCount"
+                Table false
+                Attribute "blockCacheEvictionCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheFreeSize"
+                Table false
+                Attribute "blockCacheFreeSize"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheHitCount"
+                Table false
+                Attribute "blockCacheHitCount"
+            </Value>
+
+            # The two attributes below are identical; one is a renamed version of the other.
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheHitPercent"
+                Table false
+                # This is the name used in HBase 0.98 and earlier.
+                Attribute "blockCountHitPercent"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheHitPercent"
+                Table false
+                Attribute "blockCacheCountHitPercent"
+            </Value>
+
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheMissCount"
+                Table false
+                Attribute "blockCacheMissCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheSize"
+                Table false
+                Attribute "blockCacheSize"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-compactionQueueLength"
+                Table false
+                Attribute "compactionQueueLength"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-flushQueueLength"
+                Table false
+                Attribute "flushQueueLength"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-memStoreSize"
+                Table false
+                Attribute "memStoreSize"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-storeCount"
+                Table false
+                Attribute "storeCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-readRequestCount"
+                Table false
+                Attribute "readRequestCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-storeFileIndexSize"
+                Table false
+                Attribute "storeFileIndexSize"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-writeRequestCount"
+                Table false
+                Attribute "writeRequestCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-totalRequestCount"
+                Table false
+                Attribute "totalRequestCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-slowAppendCount"
+                Table false
+                Attribute "slowAppendCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-slowPutCount"
+                Table false
+                Attribute "slowPutCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-slowGetCount"
+                Table false
+                Attribute "slowGetCount"
+            </Value>
+        </MBean>
+
+
+        <Connection>
+            ServiceURL "{{ hbase-098-standalone_service_url }}"
+
+            Collect "hbase_master_Server"
+            Collect "hbase_ipc_IPC"
+        </Connection>
+
+        <Connection>
+            ServiceURL "{{ hbase-098-standalone_service_url }}"
+            InstancePrefix "hbaseregionserver"
+
+            Collect "hbase_regionserver_RegionServerStatistics"
+        </Connection>
+
+
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "{{ hbase-098-standalone_service_url }}"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+<Chain "GenericJMX_hbase">
+    <Rule "rewrite_genericjmx_to_hbase">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^hbase.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "hbase" ""
+        </Target>
+        <Target "set">
+            Plugin "hbase"
+        </Target>
+    </Rule>
+    <Rule "go_back">
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_hbase">
+        <Target "jump">
+            Chain "GenericJMX_hbase"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"
+
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"

--- a/templates/hbase-098.conf
+++ b/templates/hbase-098.conf
@@ -1,0 +1,369 @@
+# This is the monitoring configuration for HBase 0.98 and later running in distributed mode.
+# Look for hbase-098_host, hbase-098_master_port, and hbase-098_regionserver_port to adjust your configuration file.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "hbase_master_Server">
+            ObjectName "Hadoop:service=HBase,name=Master,sub=Server"
+            <Value>
+                Type "gauge"
+                InstancePrefix "master-averageLoad"
+                Table false
+                Attribute "averageLoad"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "master-numRegionServers"
+                Table false
+                Attribute "numRegionServers"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "master-numDeadRegionServers"
+                Table false
+                Attribute "numDeadRegionServers"
+            </Value>
+        </MBean>
+
+        <MBean "hbase_ipc_IPC">
+            ObjectName "Hadoop:service=HBase,name=IPC,sub=IPC"
+            <Value>
+                Type "counter"
+                InstancePrefix "ipc-sentBytes"
+                Table false
+                Attribute "sentBytes"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "ipc-receivedBytes"
+                Table false
+                Attribute "receivedBytes"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "ipc-queueSize"
+                Table false
+                Attribute "queueSize"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "ipc-numOpenConnections"
+                Table false
+                Attribute "numOpenConnections"
+            </Value>
+        </MBean>
+
+        <MBean "hbase_regionserver_RegionServerStatistics">
+            ObjectName "Hadoop:service=HBase,name=RegionServer,sub=Server"
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheCount"
+                Table false
+                Attribute "blockCacheCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheEvictedCount"
+                Table false
+                Attribute "blockCacheEvictionCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheFreeSize"
+                Table false
+                Attribute "blockCacheFreeSize"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheHitCount"
+                Table false
+                Attribute "blockCacheHitCount"
+            </Value>
+
+            # The two attributes below are identical; one is a renamed version of the other.
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheHitPercent"
+                Table false
+                # This is the name used in HBase 0.98 and earlier.
+                Attribute "blockCountHitPercent"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheHitPercent"
+                Table false
+                Attribute "blockCacheCountHitPercent"
+            </Value>
+
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-blockCacheMissCount"
+                Table false
+                Attribute "blockCacheMissCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-blockCacheSize"
+                Table false
+                Attribute "blockCacheSize"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-compactionQueueLength"
+                Table false
+                Attribute "compactionQueueLength"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-flushQueueLength"
+                Table false
+                Attribute "flushQueueLength"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-memStoreSize"
+                Table false
+                Attribute "memStoreSize"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-storeCount"
+                Table false
+                Attribute "storeCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-readRequestCount"
+                Table false
+                Attribute "readRequestCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "regionserver-storeFileIndexSize"
+                Table false
+                Attribute "storeFileIndexSize"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-writeRequestCount"
+                Table false
+                Attribute "writeRequestCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-totalRequestCount"
+                Table false
+                Attribute "totalRequestCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-slowAppendCount"
+                Table false
+                Attribute "slowAppendCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-slowPutCount"
+                Table false
+                Attribute "slowPutCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "regionserver-slowGetCount"
+                Table false
+                Attribute "slowGetCount"
+            </Value>
+        </MBean>
+
+
+        <Connection>
+            ServiceURL "service:jmx:rmi:///jndi/rmi://{{ hbase-098_host }}:{{ hbase-098_master_port }}/jmxrmi"
+            InstancePrefix "hbasemaster"
+
+            Collect "hbase_master_Server"
+            Collect "hbase_ipc_IPC"
+        </Connection>
+
+        <Connection>
+            ServiceURL "service:jmx:rmi:///jndi/rmi://{{ hbase-098_host }}:{{ hbase-098_regionserver_port }}/jmxrmi"
+            InstancePrefix "hbaseregionserver"
+
+            Collect "hbase_regionserver_RegionServerStatistics"
+        </Connection>
+
+
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "service:jmx:rmi:///jndi/rmi://{{ hbase-098_host }}:{{ hbase-098_regionserver_port }}/jmxrmi"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+<Chain "GenericJMX_hbase">
+    <Rule "rewrite_genericjmx_to_hbase">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^hbase.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "hbase" ""
+        </Target>
+        <Target "set">
+            Plugin "hbase"
+        </Target>
+    </Rule>
+    <Rule "go_back">
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_hbase">
+        <Target "jump">
+            Chain "GenericJMX_hbase"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"
+
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"

--- a/templates/jvm-sun-hotspot.conf
+++ b/templates/jvm-sun-hotspot.conf
@@ -1,0 +1,154 @@
+# This is the monitoring configuration for standalone JVMs.
+# Look for jmx_host and jmx_port to adjust your configuration file.
+# Replace jmx_port below with the value configured in your JVM deployment.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "{{ jmx_service_url }}"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"

--- a/templates/kafka-082.conf
+++ b/templates/kafka-082.conf
@@ -1,0 +1,437 @@
+# This is the monitoring configuration for Apache Kafka 0.8.2 and later.
+# Look for kafka-082_host and kafka-082_port to adjust your configuration file.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "kafka_log-LogFlushStats_LogFlush">
+            ObjectName "kafka.log:type=LogFlushStats,name=LogFlushRateAndTimeMs"
+            <Value>
+                Type "counter"
+                InstancePrefix "log-LogFlushes"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_server-BrokerTopicMetrics_AllTopicsBytesIn">
+            ObjectName "kafka.server:type=BrokerTopicMetrics,name=BytesInPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "server_broker_topics-AllTopicsBytesIn"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-BrokerTopicMetrics_AllTopicsFailedFetchRequests">
+            ObjectName "kafka.server:type=BrokerTopicMetrics,name=FailedFetchRequestsPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "server_broker_topics-AllTopicsFailedFetchRequests"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-BrokerTopicMetrics_AllTopicsFailedProduceRequests">
+            ObjectName "kafka.server:type=BrokerTopicMetrics,name=FailedProduceRequestsPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "server_broker_topics-AllTopicsFailedProduceRequests"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-BrokerTopicMetrics_AllTopicsMessagesIn">
+            ObjectName "kafka.server:type=BrokerTopicMetrics,name=MessagesInPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "server_broker_topics-AllTopicsMessagesIn"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-BrokerTopicMetrics_AllTopicsBytesOut">
+            ObjectName "kafka.server:type=BrokerTopicMetrics,name=BytesOutPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "server_broker_topics-AllTopicsBytesOut"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_server-ReplicaManager_UnderReplicatedPartitions">
+            ObjectName "kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_replica_manager-UnderReplicatedPartitions"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-ReplicaManager_PartitionCount">
+            ObjectName "kafka.server:type=ReplicaManager,name=PartitionCount"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_replica_manager-PartitionCount"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-ReplicaManager_LeaderCount">
+            ObjectName "kafka.server:type=ReplicaManager,name=LeaderCount"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_replica_manager-LeaderCount"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-ReplicaManager_ISRShrinks">
+            ObjectName "kafka.server:type=ReplicaManager,name=IsrShrinksPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "server_replica_manager-ISRShrinks"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-ReplicaManager_ISRExpands">
+            ObjectName "kafka.server:type=ReplicaManager,name=IsrExpandsPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "server_replica_manager-ISRExpands"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_server-ReplicaFetcherManager_MaxLag">
+            ObjectName "kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=Replica"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_replica_fetcher-MaxLag"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-ReplicaFetcherManager_MinFetchRate">
+            ObjectName "kafka.server:type=ReplicaFetcherManager,name=MinFetchRate,clientId=Replica"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_replica_fetcher-MinFetchRate"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_server-ProducerRequestPurgatory_NumDelayedRequests">
+            ObjectName "kafka.server:type=ProducerRequestPurgatory,name=NumDelayedRequests"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_purgatory-Producer-NumDelayedRequests"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-ProducerRequestPurgatory_PurgatorySize">
+            ObjectName "kafka.server:type=ProducerRequestPurgatory,name=PurgatorySize"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_purgatory-Producer-PurgatorySize"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_server-FetchRequestPurgatory_NumDelayedRequests">
+            ObjectName "kafka.server:type=FetchRequestPurgatory,name=NumDelayedRequests"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_purgatory-Fetch-NumDelayedRequests"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "kafka_server-FetchRequestPurgatory_PurgatorySize">
+            ObjectName "kafka.server:type=FetchRequestPurgatory,name=PurgatorySize"
+            <Value>
+                Type "gauge"
+                InstancePrefix "server_purgatory-Fetch-PurgatorySize"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_network-RequestMetrics_ProduceRequests">
+            ObjectName "kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce"
+            <Value>
+                Type "counter"
+                InstancePrefix "network-ProduceRequests"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_network-RequestMetrics_FetchFollowerRequests">
+            ObjectName "kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchFollower"
+            <Value>
+                Type "counter"
+                InstancePrefix "network-FetchFollowerRequests"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_network-RequestMetrics_FetchConsumerRequests">
+            ObjectName "kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchConsumer"
+            <Value>
+                Type "counter"
+                InstancePrefix "network-FetchConsumerRequests"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_controller-KafkaController_ActiveControllerCount">
+            ObjectName "kafka.controller:type=KafkaController,name=ActiveControllerCount"
+            <Value>
+                Type "gauge"
+                InstancePrefix "controller_kafka-ActiveControllerCount"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+        <MBean "kafka_controller-KafkaController_OfflinePartitionsCount">
+            ObjectName "kafka.controller:type=KafkaController,name=OfflinePartitionsCount"
+            <Value>
+                Type "gauge"
+                InstancePrefix "controller_kafka-OfflinePartitionsCount"
+                Table false
+                Attribute "Value"
+            </Value>
+        </MBean>
+
+        <MBean "kafka_controller-ControllerStats_LeaderElections">
+            ObjectName "kafka.controller:type=ControllerStats,name=LeaderElectionRateAndTimeMs"
+            <Value>
+                Type "counter"
+                InstancePrefix "controller-LeaderElections"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+        <MBean "kafka_controller-ControllerStats_UncleanLeaderElections">
+            ObjectName "kafka.controller:type=ControllerStats,name=UncleanLeaderElectionsPerSec"
+            <Value>
+                Type "counter"
+                InstancePrefix "controller-UncleanLeaderElections"
+                Table false
+                Attribute "Count"
+            </Value>
+        </MBean>
+
+
+        <Connection>
+            ServiceURL "{{ kafka-082_service_url }}"
+            InstancePrefix "kafka"
+
+            Collect "kafka_log-LogFlushStats_LogFlush"
+            Collect "kafka_server-BrokerTopicMetrics_AllTopicsBytesIn"
+            Collect "kafka_server-BrokerTopicMetrics_AllTopicsFailedFetchRequests"
+            Collect "kafka_server-BrokerTopicMetrics_AllTopicsFailedProduceRequests"
+            Collect "kafka_server-BrokerTopicMetrics_AllTopicsMessagesIn"
+            Collect "kafka_server-BrokerTopicMetrics_AllTopicsBytesOut"
+            Collect "kafka_server-ReplicaManager_UnderReplicatedPartitions"
+            Collect "kafka_server-ReplicaManager_PartitionCount"
+            Collect "kafka_server-ReplicaManager_LeaderCount"
+            Collect "kafka_server-ReplicaManager_ISRShrinks"
+            Collect "kafka_server-ReplicaManager_ISRExpands"
+            Collect "kafka_server-ReplicaFetcherManager_MaxLag"
+            Collect "kafka_server-ReplicaFetcherManager_MinFetchRate"
+            Collect "kafka_server-ProducerRequestPurgatory_NumDelayedRequests"
+            Collect "kafka_server-ProducerRequestPurgatory_PurgatorySize"
+            Collect "kafka_server-FetchRequestPurgatory_NumDelayedRequests"
+            Collect "kafka_server-FetchRequestPurgatory_PurgatorySize"
+            Collect "kafka_network-RequestMetrics_ProduceRequests"
+            Collect "kafka_network-RequestMetrics_FetchFollowerRequests"
+            Collect "kafka_network-RequestMetrics_FetchConsumerRequests"
+            Collect "kafka_controller-KafkaController_ActiveControllerCount"
+            Collect "kafka_controller-KafkaController_OfflinePartitionsCount"
+            Collect "kafka_controller-ControllerStats_LeaderElections"
+            Collect "kafka_controller-ControllerStats_UncleanLeaderElections"
+        </Connection>
+
+
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "{{ kafka-082_service_url }}"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+<Chain "GenericJMX_kafka">
+    <Rule "rewrite_genericjmx_to_kafka">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^kafka.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "kafka" ""
+        </Target>
+        <Target "set">
+            Plugin "kafka"
+        </Target>
+    </Rule>
+    <Rule "go_back">
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_kafka">
+        <Target "jump">
+            Chain "GenericJMX_kafka"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"
+
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"

--- a/templates/memcached.conf
+++ b/templates/memcached.conf
@@ -1,0 +1,7 @@
+# This is the monitoring configuration for memcached.
+# Look for memcached_host and memcached_port to adjust your configuration file.
+LoadPlugin memcached
+<Plugin "memcached">
+    Host "{{ memcached_host }}"
+    Port "{{ memcached_port }}"
+</Plugin>

--- a/templates/mysql.conf
+++ b/templates/mysql.conf
@@ -1,0 +1,17 @@
+# This is the monitoring configuration for MySQL.
+# NOTE: This configuration needs to be hand-edited in order to work.
+# Look for mysql_database_name, mysql_host, mysql_port, mysql_user and mysql_pass to adjust your configuration file.
+LoadPlugin mysql
+<Plugin "mysql">
+    # Each database needs a separate Database section.
+    <Database "{{ mysql_database_name }}">
+        Host "{{ mysql_host }}"
+        Port "{{ mysql_port }}"
+        User "{{ mysql_user }}"
+        Password "{{ mysql_pass }}"
+        MasterStats true
+        SlaveStats true
+        # Uncomment the following line if you want to collect InnoDB metrics.
+        #InnodbStats true
+    </Database>
+</Plugin>

--- a/templates/nginx.conf
+++ b/templates/nginx.conf
@@ -1,0 +1,7 @@
+# This is the monitoring configuration for Nginx.
+# Make sure to enable stub_status in your Nginx configuration.
+# Look for nginx_host and nginx_port to adjust your configuration file.
+LoadPlugin nginx
+<Plugin "nginx">
+    URL "{{ nginx_status_url }}"
+</Plugin>

--- a/templates/redis.conf
+++ b/templates/redis.conf
@@ -1,0 +1,14 @@
+# This is the monitoring configuration for Redis.
+# Make sure you've installed the hiredis/libhiredis packages.
+# Look for redis_host, redis_port, redis_timeout and redis_pass to adjust your configuration file.
+LoadPlugin redis
+<Plugin "redis">
+    <Node "{{ redis_name }}">
+        Host "{{ redis_host }}"
+        Port "{{ redis_port }}"
+        Timeout "{{ redis_timeout }}"
+    {% if redis_password %}
+        Password "{{ redis_password }}"
+    {% endif %}
+    </Node>
+</Plugin>

--- a/templates/statsd.conf
+++ b/templates/statsd.conf
@@ -1,0 +1,32 @@
+# This is the monitoring configuration for StatsD.
+# Look for statsd_host and statsd_port to adjust your configuration file.
+LoadPlugin statsd
+
+<Plugin statsd>
+  Host "{{ statsd_host }}"
+  Port "{{ statsd_port }}"
+  DeleteSets true
+  TimerPercentile 50.0
+  TimerPercentile 95.0
+  TimerLower true
+  TimerUpper true
+  TimerSum true
+  TimerCount true
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+
+PreCacheChain "PreCache"
+<Chain "PreCache">
+  <Rule "rewrite_statsd">
+    <Match regex>
+      Plugin "^statsd$"
+    </Match>
+    <Target "set">
+      MetaData "stackdriver_metric_type" "custom.googleapis.com/statsd/%{type}"
+      MetaData "label:metric" "%{type_instance}"
+    </Target>
+  </Rule>
+</Chain>

--- a/templates/tomcat-7.conf
+++ b/templates/tomcat-7.conf
@@ -1,0 +1,255 @@
+# This is the monitoring configuration for Apache Tomcat 7.x and earlier.
+# Make sure to enable JMX in your Tomcat configuration.
+# Look for tomcat-7_host and tomcat-7_port to adjust your configuration file.
+LoadPlugin java
+<Plugin "java">
+    JVMARG "-Djava.class.path=/opt/stackdriver/collectd/share/collectd/java/collectd-api.jar:/opt/stackdriver/collectd/share/collectd/java/generic-jmx.jar"
+    LoadPlugin "org.collectd.java.GenericJMX"
+
+    <Plugin "GenericJMX">
+        <MBean "tomcat_connectors">
+            ObjectName "Catalina:type=ThreadPool,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "gauge"
+                InstancePrefix "connectors-current_threads"
+                Table false
+                Attribute "currentThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "connectors-busy_threads"
+                Table false
+                Attribute "currentThreadsBusy"
+            </Value>
+        </MBean>
+
+        <MBean "tomcat_manager">
+            ObjectName "Catalina:type=Manager,context=*,host=*"
+            InstanceFrom "context"
+            <Value>
+                Type "gauge"
+                InstancePrefix "manager-active_sessions"
+                Table false
+                Attribute "activeSessions"
+            </Value>
+        </MBean>
+
+        <MBean "tomcat_requestProcessor">
+            ObjectName "Catalina:type=GlobalRequestProcessor,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "request_processor-bytes_received"
+                Table false
+                Attribute "bytesReceived"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "request_processor-bytes_sent"
+                Table false
+                Attribute "bytesSent"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "request_processor-processing_time"
+                Table false
+                Attribute "processingTime"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "request_processor-request_count"
+                Table false
+                Attribute "requestCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "request_processor-error_count"
+                Table false
+                Attribute "errorCount"
+            </Value>
+        </MBean>
+
+
+        <Connection>
+            ServiceURL "{{ tomcat-7_service_url }}"
+            InstancePrefix "tomcat"
+
+            Collect "tomcat_connectors"
+            Collect "tomcat_manager"
+            Collect "tomcat_requestProcessor"
+        </Connection>
+
+
+        <MBean "jvm_localhost_Threading">
+            ObjectName "java.lang:type=Threading"
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-daemon_thread_count"
+                Table false
+                Attribute "DaemonThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-thread_count"
+                Table false
+                Attribute "ThreadCount"
+            </Value>
+            <Value>
+                Type "gauge"
+                InstancePrefix "threading-peak_thread_count"
+                Table false
+                Attribute "PeakThreadCount"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Memory">
+            ObjectName "java.lang:type=Memory"
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_committed"
+                Table false
+                Attribute "HeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_committed"
+                Table false
+                Attribute "NonHeapMemoryUsage.committed"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_used"
+                Table false
+                Attribute "HeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_used"
+                Table false
+                Attribute "NonHeapMemoryUsage.used"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-heap_usage_max"
+                Table false
+                Attribute "HeapMemoryUsage.max"
+            </Value>
+            <Value>
+                Type "memory"
+                InstancePrefix "memory-non_heap_usage_max"
+                Table false
+                Attribute "NonHeapMemoryUsage.max"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_Runtime">
+            ObjectName "java.lang:type=Runtime"
+            <Value>
+                Type "counter"
+                InstancePrefix "runtime-uptime"
+                Table false
+                Attribute "Uptime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_os">
+            ObjectName "java.lang:type=OperatingSystem"
+            <Value>
+                Type "gauge"
+                InstancePrefix "os-open_fd_count"
+                Table false
+                Attribute "OpenFileDescriptorCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "os-process_cpu_time"
+                Table false
+                Attribute "ProcessCpuTime"
+            </Value>
+        </MBean>
+
+        <MBean "jvm_localhost_gc">
+            ObjectName "java.lang:type=GarbageCollector,name=*"
+            InstanceFrom "name"
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_count"
+                Table false
+                Attribute "CollectionCount"
+            </Value>
+            <Value>
+                Type "counter"
+                InstancePrefix "gc-collection_time"
+                Table false
+                Attribute "CollectionTime"
+            </Value>
+        </MBean>
+
+        <Connection>
+            ServiceURL "{{ tomcat-7_service_url }}"
+            InstancePrefix "jvm"
+
+            Collect "jvm_localhost_Threading"
+            Collect "jvm_localhost_Memory"
+            Collect "jvm_localhost_Runtime"
+            Collect "jvm_localhost_os"
+            Collect "jvm_localhost_gc"
+        </Connection>
+    </Plugin>
+</Plugin>
+
+LoadPlugin match_regex
+LoadPlugin target_set
+LoadPlugin target_replace
+<Chain "GenericJMX_tomcat">
+    <Rule "rewrite_genericjmx_to_tomcat">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^tomcat.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "tomcat" ""
+        </Target>
+        <Target "set">
+            Plugin "tomcat"
+        </Target>
+    </Rule>
+    <Rule "go_back">
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_tomcat">
+        <Target "jump">
+            Chain "GenericJMX_tomcat"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"
+
+<Chain "GenericJMX_jvm">
+    <Rule "rewrite_genericjmx_to_jvm">
+        <Match regex>
+            Plugin "^GenericJMX$"
+            PluginInstance "^jvm.*$"
+        </Match>
+        <Target "replace">
+            PluginInstance "jvm" ""
+        </Target>
+        <Target "set">
+            Plugin "jvm"
+        </Target>
+        Target "return"
+    </Rule>
+</Chain>
+
+<Chain "PreCache">
+    <Rule "jump_to_GenericJMX_jvm">
+        <Target "jump">
+            Chain "GenericJMX_jvm"
+        </Target>
+    </Rule>
+</Chain>
+PreCacheChain "PreCache"


### PR DESCRIPTION
Add support for montioring apache, cassandra, hbase, kafka, tomcat, jvm-sun-hotspot, memcached, mysql, nginx, redis, and statsd.