### PR TITLE
Add support for custom configs and third party monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,18 @@ https://cloud.google.com/monitoring/agent/authorization#before_you_begin
 Role Variables
 --------------
 
-The monitoring agent can be configured by supplying a path to a custom
-configuration file using the variable `monitoring_main_config_file`. On the
-target VMs, this custom configuration file will be deployed to the location at
-`/etc/stackdriver/collectd.conf`.
+The agents can be configured by supplying a path to a custom configuration
+file using the variable `main_config_file`. This custom configuration file will
+overwrite the configuration file on the target VM.
 
 For more information please see [Configuring the Cloud Monitoring agent](https://cloud.google.com/monitoring/agent/configuration).
 
-By default, the agent only monitors system resources like cpu, memory, disk etc.
-Third party application monitoring can be configured by supplying a path to a
-directory containing plugin configuration files using the variable
-`monitoring_additional_config_dir`. On the target VMs, all `.conf` files under
-this directory will be deployed to the location at
-`/etc/stackdriver/collectd.d`. The root level config file at
-`/etc/stackdriver/collectd.conf` should have a line that includes this
-directory.
+By default, the agent only monitors and logs system resources like cpu, memory,
+disk etc. Third party application monitoring and logging can be configured by
+supplying a path to a directory containing plugin configuration files using the
+variable `additional_config_dir`. All `.conf` files under this directory will be
+deployed to the agent's plugin directory on the target VM. The main config file
+should have a line that includes this directory.
 
 For more information please see [Monitoring third-party applications](https://cloud.google.com/monitoring/agent/plugins).
 
@@ -51,7 +48,7 @@ Example Playbook
     - role: cloud_ops
       vars:
         agent_type: monitoring
-        monitoring_config_file_local: collectd.conf
+        config_file_local: collectd.conf
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ Compute Engine instances created without the default credentials, then you must
 complete the following steps
 https://cloud.google.com/monitoring/agent/authorization#before_you_begin
 
+Role Variables
+--------------
+
+The monitoring agent can be configured by supplying a path to a custom
+configuration file using the variable `monitoring_config_file_local`.
+
+For more information please see [Configuring the Cloud Monitoring agent](https://cloud.google.com/monitoring/agent/configuration).
+
+By default, no plugins are enabled, in which case the agent will only monitor
+certain system resources. Third party application monitoring can be configured
+by supplying a path to a directory containing plugin configuration files using
+the variable `monitoring_plugin_dir_local`.
+
+For more information please see [Monitoring third-party applications](https://cloud.google.com/monitoring/agent/plugins).
+
 Example Playbook
 ----------------
 
@@ -29,7 +44,8 @@ Example Playbook
   roles:
     - role: cloud_ops
       vars:
-        agent_type: "monitoring"
+        agent_type: monitoring
+        monitoring_config_file_local: collectd.conf
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -23,14 +23,20 @@ Role Variables
 --------------
 
 The monitoring agent can be configured by supplying a path to a custom
-configuration file using the variable `monitoring_config_file_local`.
+configuration file using the variable `monitoring_main_config_file`. On the
+target VMs, this custom configuration file will be deployed to the location at
+`/etc/stackdriver/collectd.conf`.
 
 For more information please see [Configuring the Cloud Monitoring agent](https://cloud.google.com/monitoring/agent/configuration).
 
-By default, no plugins are enabled, in which case the agent will only monitor
-certain system resources. Third party application monitoring can be configured
-by supplying a path to a directory containing plugin configuration files using
-the variable `monitoring_plugin_dir_local`.
+By default, the agent only monitors system resources like cpu, memory, disk etc.
+Third party application monitoring can be configured by supplying a path to a
+directory containing plugin configuration files using the variable
+`monitoring_additional_config_dir`. On the target VMs, all `.conf` files under
+this directory will be deployed to the location at
+`/etc/stackdriver/collectd.d`. The root level config file at
+`/etc/stackdriver/collectd.conf` should have a line that includes this
+directory.
 
 For more information please see [Monitoring third-party applications](https://cloud.google.com/monitoring/agent/plugins).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ monitoring_service_name: stackdriver-agent
 # Local path to the config file to copy onto the remote server. Can be absolute or relative.
 monitoring_main_config_file: ""
 
-# Local path to the plugin dir whose contents will be copied onto the remote server. Can be absolute or relative.
+# Local path to the additonal config directory whose contents will be copied onto the remote server. Can be absolute or relative.
 monitoring_additional_config_dir: ""
 
 monitoring_binary: /opt/stackdriver/collectd/sbin/stackdriver-collectd

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,17 @@
 ---
 agent_type: ""
-package_state: "present"
+package_state: present
 
-# default vars for the monitoring agent
+# Default vars for the monitoring agent
 monitoring_package_name: stackdriver-agent
 monitoring_service_name: stackdriver-agent
+
+# Local path to the config file to copy onto the remote server. Can be absolute or relative.
+monitoring_config_file_local: ""
+monitoring_config_file_remote: /etc/stackdriver/test.conf
+
+# Local path to the plugin dir whose contents will be copied onto the remote server. Can be absolute or relative.
+monitoring_plugin_dir_local: ""
+monitoring_plugin_dir_remote: /opt/stackdriver/collectd/etc/collectd.d/
+
+monitoring_binary: /opt/stackdriver/collectd/sbin/stackdriver-collectd

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,15 +1,14 @@
 ---
 agent_type: ""
 package_state: present
+# Local path to the config file to copy onto the remote server. Can be absolute or relative.
+main_config_file: ""
+# Local path to the additonal config directory whose contents will be copied onto the remote server. Can be absolute or relative.
+additional_config_dir: ""
+
 
 # Default vars for the monitoring agent
 monitoring_package_name: stackdriver-agent
 monitoring_service_name: stackdriver-agent
-
-# Local path to the config file to copy onto the remote server. Can be absolute or relative.
-monitoring_main_config_file: ""
-
-# Local path to the additonal config directory whose contents will be copied onto the remote server. Can be absolute or relative.
-monitoring_additional_config_dir: ""
 
 monitoring_binary: /opt/stackdriver/collectd/sbin/stackdriver-collectd

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,11 +7,9 @@ monitoring_package_name: stackdriver-agent
 monitoring_service_name: stackdriver-agent
 
 # Local path to the config file to copy onto the remote server. Can be absolute or relative.
-monitoring_config_file_local: ""
-monitoring_config_file_remote: /etc/stackdriver/test.conf
+monitoring_main_config_file: ""
 
 # Local path to the plugin dir whose contents will be copied onto the remote server. Can be absolute or relative.
-monitoring_plugin_dir_local: ""
-monitoring_plugin_dir_remote: /opt/stackdriver/collectd/etc/collectd.d/
+monitoring_additional_config_dir: ""
 
 monitoring_binary: /opt/stackdriver/collectd/sbin/stackdriver-collectd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Fail if agent type is not supported
   assert:
     that: agent_type in ["monitoring"]
-    msg: "Received invalid agent type: '{{ agent_type }}'. The Cloud Ops Ansible role only supports the following agents: 'monitoring', 'logging' and 'ops_agent'."
+    msg: "Received invalid agent type: '{{ agent_type }}'. The Cloud Ops Ansible role supports the following agents: 'monitoring', 'logging' and 'ops_agent'."
 
 - name: Call agent-specific playbook
   include_tasks: "{{ agent_type }}.yml"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -5,16 +5,23 @@
     msg: "Received invalid package state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
 - block:
+  - name: Create temp directory
+    tempfile:
+      path: /tmp
+      state: directory
+      suffix: cloud_ops_shell_scripts
+    register: tempfolder
+
   - name: Download script
     get_url:
       url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
-      dest: /tmp/add-monitoring-agent-repo.sh
+      dest: "{{ tempfolder.path }}/add-monitoring-agent-repo.sh"
       force: yes
       mode: 0755
 
   - name: Add repo
     command:
-      chdir: /tmp
+      chdir: "{{ tempfolder.path }}"
       cmd: bash add-monitoring-agent-repo.sh
     notify: restart monitoring agent
 

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -28,22 +28,22 @@
 
 - name: Copy main config file onto the remote machine
   copy:
-    src: "{{ monitoring_config_file_local }}"
-    dest: "{{ monitoring_config_file_remote }}"
+    src: "{{ monitoring_main_config_file }}"
+    dest: /etc/stackdriver/collectd.conf
     force: yes
     mode: 0644
     validate: "{{ monitoring_binary }} -tC %s"
-  when: monitoring_config_file_local|length > 0
+  when: monitoring_main_config_file|length > 0
   notify: restart monitoring agent
 
-- name: Copy plugin configs onto the remote machine
+- name: Copy additional configs onto the remote machine
   copy:
     src: "{{ item }}"
-    dest: "{{ monitoring_plugin_dir_remote }}"
+    dest: /etc/stackdriver/collectd.d/
     force: yes
     mode: 0644
     validate: "{{ monitoring_binary }} -tC %s"
   with_fileglob:
-    - "{{ monitoring_plugin_dir_local }}/*.conf"
-  when: monitoring_plugin_dir_local|length > 0
+    - "{{ monitoring_additional_config_dir }}/*.conf"
+  when: monitoring_additional_config_dir|length > 0
   notify: restart monitoring agent

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -2,7 +2,7 @@
 - name: Fail if package state is not supported
   assert:
     that: package_state in ["present", "absent"]
-    msg: "Received invalid pacakge state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
+    msg: "Received invalid package state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
 - block:
   - name: Download script

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -2,13 +2,14 @@
 - name: Fail if package state is not supported
   assert:
     that: package_state in ["present", "absent"]
-    msg: "Received invalid pacakge state: '{{ package_state }}'. The Cloud Ops Ansible role only supports the following package states: 'present' and 'absent'."
+    msg: "Received invalid pacakge state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
 - block:
   - name: Download script
     get_url:
       url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
       dest: /tmp/add-monitoring-agent-repo.sh
+      force: yes
       mode: 0755
 
   - name: Add repo
@@ -24,3 +25,25 @@
     name: "{{ monitoring_package_name }}"
     state: "{{ package_state }}"
 #TODO(rmoriar1): Clean up the repo when package_state is absent.
+
+- name: Copy main config file onto the remote machine
+  copy:
+    src: "{{ monitoring_config_file_local }}"
+    dest: "{{ monitoring_config_file_remote }}"
+    force: yes
+    mode: 0644
+    validate: "{{ monitoring_binary }} -tC %s"
+  when: monitoring_config_file_local|length > 0
+  notify: restart monitoring agent
+
+- name: Copy plugin configs onto the remote machine
+  copy:
+    src: "{{ item }}"
+    dest: "{{ monitoring_plugin_dir_remote }}"
+    force: yes
+    mode: 0644
+    validate: "{{ monitoring_binary }} -tC %s"
+  with_fileglob:
+    - "{{ monitoring_plugin_dir_local }}/*.conf"
+  when: monitoring_plugin_dir_local|length > 0
+  notify: restart monitoring agent

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -28,12 +28,12 @@
 
 - name: Copy main config file onto the remote machine
   copy:
-    src: "{{ monitoring_main_config_file }}"
+    src: "{{ main_config_file }}"
     dest: /etc/stackdriver/collectd.conf
     force: yes
     mode: 0644
     validate: "{{ monitoring_binary }} -tC %s"
-  when: monitoring_main_config_file|length > 0
+  when: main_config_file|length > 0
   notify: restart monitoring agent
 
 - name: Copy additional configs onto the remote machine
@@ -44,6 +44,6 @@
     mode: 0644
     validate: "{{ monitoring_binary }} -tC %s"
   with_fileglob:
-    - "{{ monitoring_additional_config_dir }}/*.conf"
-  when: monitoring_additional_config_dir|length > 0
+    - "{{ additional_config_dir }}/*.conf"
+  when: additional_config_dir|length > 0
   notify: restart monitoring agent


### PR DESCRIPTION
Add main config file var, which will be moved onto the remote server if set. Add plugin dir var, whose contents will be moved onto the remote server if set. Update readme.