### PR TITLE
Uninstall via shell script rather than using the package module, Add support for check mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Ansible Role for Cloud Ops
-============================
+==========================
 
 This Ansible role installs the Cloud Ops monitoring agent (which is based on
 `collectd`).
@@ -49,18 +49,19 @@ recommended for production environments to ensure safer agent deployments.
 recommended since it prevents upgrades of new versions of the agent that include
 bug fixes and other improvements.
 
-The `main_config_file` variable can be used to supply a path to a custom
-configuration file. This file will overwrite the configuration file on the
-target VM.
+The `main_config_file` variable can be used to supply an absolute or relative
+path to a custom configuration file. This file will overwrite the configuration
+file on the target VM.
 
 For more information please see [Configuring the Cloud Monitoring
 agent](https://cloud.google.com/monitoring/agent/configuration).
 
 By default, the agent only monitors and logs system resources like cpu, memory,
-disk etc. The `additional_config_dir` variable can be used to enable third party
-application monitoring and logging. All `.conf` files under this directory will
-be deployed to the agent's plugin directory on the target VM. The main config
-file should have a line that includes this directory.
+disk etc. The `additional_config_dir` variable can be used to supply an absolute
+or relative path to a directory containing plugins for third party application
+monitoring and logging. All `.conf` files under this directory will be deployed
+to the agent's plugin directory on the target VM. The main config file should
+have a line that includes this directory.
 
 For more information please see [Monitoring third-party
 applications](https://cloud.google.com/monitoring/agent/plugins).
@@ -80,7 +81,6 @@ Example Playbook
         version: latest
         config_file_local: collectd.conf
         additional_config_dir: plugins/
-
 ```
 
 License
@@ -89,15 +89,14 @@ License
 ```
 Copyright 2020 Google Inc. All rights reserved.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.  You may obtain a copy of the
+License at
 
     http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations under the License.
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-```diff
-- Under active development and not yet suitable for use.
-```
+Warning: This repo is under active development and not yet suitable for use.
 
 Ansible Role for Cloud Ops
 ==========================

--- a/README.md
+++ b/README.md
@@ -25,23 +25,22 @@ Role Variables
 The `agent_type` is a required variable used to specify which agent is being
 configured. The available options are `monitoring`, `logging` and `ops_agent`.
 
-The `package_state` variable can be used to specify the state you'd like the
-agent to be in. The allowed values are `present` (default) and `absent`.
+The `package_state` variable can be used to specify the desired state of the
+agent. The allowed values are `present` (default) and `absent`.
 
-A specific version of the agent can be installed by modifying the `version`
-variable. The allowed values are `latest` (default), `MAJOR_VERSION.*.*`
-and `MAJOR_VERSION.MINOR_VERSION.PATCH_VERSION`.
+The `version` variable can be used to specify which version of the agent to
+install. The allowed values are `latest` (default), `MAJOR_VERSION.*.*` and
+`MAJOR_VERSION.MINOR_VERSION.PATCH_VERSION`.
 
-The agents can be configured by supplying a path to a custom configuration
-file using the variable `main_config_file`. This custom configuration file will
-overwrite the configuration file on the target VM.
+The `main_config_file` variable can be used to supply a path to a custom
+configuration file. This file will overwrite the configuration file on the
+target VM.
 
 For more information please see [Configuring the Cloud Monitoring agent](https://cloud.google.com/monitoring/agent/configuration).
 
 By default, the agent only monitors and logs system resources like cpu, memory,
-disk etc. Third party application monitoring and logging can be configured by
-supplying a path to a directory containing plugin configuration files using the
-variable `additional_config_dir`. All `.conf` files under this directory will be
+disk etc. The `additional_config_dir` variable can be used to enable third party
+application monitoring and logging. All `.conf` files under this directory will be
 deployed to the agent's plugin directory on the target VM. The main config file
 should have a line that includes this directory.
 
@@ -58,8 +57,10 @@ Example Playbook
     - role: cloud_ops
       vars:
         agent_type: monitoring
+        package_state: present
         version: latest
         config_file_local: collectd.conf
+        additional_config_dir: plugins/
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-<span style="color:red"> Under active development and not yet suitable for use.</span>
+```diff
+- Under active development and not yet suitable for use.
+```
+
 Ansible Role for Cloud Ops
 ==========================
 

--- a/README.md
+++ b/README.md
@@ -30,21 +30,40 @@ agent. The allowed values are `present` (default) and `absent`.
 
 The `version` variable can be used to specify which version of the agent to
 install. The allowed values are `latest` (default), `MAJOR_VERSION.*.*` and
-`MAJOR_VERSION.MINOR_VERSION.PATCH_VERSION`.
+`MAJOR_VERSION.MINOR_VERSION.PATCH_VERSION`, which are described in detail
+below.
+
+`version=latest` This setting makes it easier to keep the agent version up to
+date, however it does come with a potential risk. When a new major version is
+released, the policy may install the latest version of the agent from the new
+major release, which may introduce breaking changes. For production
+environments, consider using `version=MAJOR_VERSION.*.*` setting below for safer
+agent deployments.
+
+`version=MAJOR_VERSION.*.*` When a new major release is out, this setting
+ensures that only the latest version from the specified major version is
+installed, which avoids accidentally introducing breaking changes. This is
+recommended for production environments to ensure safer agent deployments.
+
+`version=MAJOR_VERSION.MINOR_VERSION.PATCH_VERSION` This setting is not
+recommended since it prevents upgrades of new versions of the agent that include
+bug fixes and other improvements.
 
 The `main_config_file` variable can be used to supply a path to a custom
 configuration file. This file will overwrite the configuration file on the
 target VM.
 
-For more information please see [Configuring the Cloud Monitoring agent](https://cloud.google.com/monitoring/agent/configuration).
+For more information please see [Configuring the Cloud Monitoring
+agent](https://cloud.google.com/monitoring/agent/configuration).
 
 By default, the agent only monitors and logs system resources like cpu, memory,
 disk etc. The `additional_config_dir` variable can be used to enable third party
-application monitoring and logging. All `.conf` files under this directory will be
-deployed to the agent's plugin directory on the target VM. The main config file
-should have a line that includes this directory.
+application monitoring and logging. All `.conf` files under this directory will
+be deployed to the agent's plugin directory on the target VM. The main config
+file should have a line that includes this directory.
 
-For more information please see [Monitoring third-party applications](https://cloud.google.com/monitoring/agent/plugins).
+For more information please see [Monitoring third-party
+applications](https://cloud.google.com/monitoring/agent/plugins).
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Requirements
 Permissions to Google Cloud API. If running on an old Compute Engine instance or
 Compute Engine instances created without the default credentials, then you must
 complete the following steps
-https://cloud.google.com/monitoring/agent/authorization#before_you_begin
+https://cloud.google.com/monitoring/agent/authorization#before_you_begin.
 
 Role Variables
 --------------
 
 The `agent_type` is a required variable used to specify which agent is being
-configured. The available options are `monitoring`, `logging` and `ops_agent`.
+configured. The available options are `monitoring`, `logging` and `ops-agent`.
 
 The `package_state` variable can be used to specify the desired state of the
 agent. The allowed values are `present` (default) and `absent`.
@@ -53,7 +53,7 @@ The `main_config_file` variable can be used to supply an absolute or relative
 path to a custom configuration file. This file will overwrite the configuration
 file on the target VM.
 
-For more information please see [Configuring the Monitoring
+For more information, please see [Configuring the Monitoring
 Agent](https://cloud.google.com/monitoring/agent/configuration), [Configuring
 the Logging
 Agent](https://cloud.google.com/logging/docs/agent/configuration?hl=en#configure)
@@ -67,7 +67,7 @@ monitoring and logging. All `.conf` files under this directory will be deployed
 to the agent's plugin directory on the target VM. The main config file should
 have a line that includes this directory.
 
-For more information please see [Monitoring third-party
+For more information, please see [Monitoring third-party
 applications](https://cloud.google.com/monitoring/agent/plugins).
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<span style="color:red"> Under active development and not yet suitable for use.</span>
 Ansible Role for Cloud Ops
 ==========================
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ below.
 date, however it does come with a potential risk. When a new major version is
 released, the policy may install the latest version of the agent from the new
 major release, which may introduce breaking changes. For production
-environments, consider using `version=MAJOR_VERSION.*.*` setting below for safer
-agent deployments.
+environments, consider using the `version=MAJOR_VERSION.*.*` setting below for
+safer agent deployments.
 
 `version=MAJOR_VERSION.*.*` When a new major release is out, this setting
 ensures that only the latest version from the specified major version is
@@ -53,8 +53,12 @@ The `main_config_file` variable can be used to supply an absolute or relative
 path to a custom configuration file. This file will overwrite the configuration
 file on the target VM.
 
-For more information please see [Configuring the Cloud Monitoring
-agent](https://cloud.google.com/monitoring/agent/configuration).
+For more information please see [Configuring the Monitoring
+Agent](https://cloud.google.com/monitoring/agent/configuration), [Configuring
+the Logging
+Agent](https://cloud.google.com/logging/docs/agent/configuration?hl=en#configure)
+or [Configuring the Ops
+Agent](https://cloud.google.com/stackdriver/docs/solutions/ops-agent/configuration?hl=en)
 
 By default, the agent only monitors and logs system resources like cpu, memory,
 disk etc. The `additional_config_dir` variable can be used to supply an absolute

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Agent](https://cloud.google.com/monitoring/agent/configuration), [Configuring
 the Logging
 Agent](https://cloud.google.com/logging/docs/agent/configuration?hl=en#configure)
 or [Configuring the Ops
-Agent](https://cloud.google.com/stackdriver/docs/solutions/ops-agent/configuration?hl=en)
+Agent](https://cloud.google.com/stackdriver/docs/solutions/ops-agent/configuration?hl=en).
 
 By default, the agent only monitors and logs system resources like cpu, memory,
 disk etc. The `additional_config_dir` variable can be used to supply an absolute

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 Warning: This repo is under active development and not yet suitable for use.
+============================================================================
 
 Ansible Role for Cloud Ops
 ==========================

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ https://cloud.google.com/monitoring/agent/authorization#before_you_begin
 Role Variables
 --------------
 
+The `agent_type` is a required variable used to specify which agent is being
+configured. The available options are `monitoring`, `logging` and `ops_agent`.
+
+The `package_state` variable can be used to specify the state you'd like the
+agent to be in. The allowed values are `present` (default) and `absent`.
+
 A specific version of the agent can be installed by modifying the `version`
 variable. The allowed values are `latest` (default), `MAJOR_VERSION.*.*`
 and `MAJOR_VERSION.MINOR_VERSION.PATCH_VERSION`.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,4 +3,4 @@
   service:
     name: stackdriver-agent
     state: restarted
-  when: not ansible_check_mode
+  when: package_state == 'present' and not ansible_check_mode

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: restart monitoring agent
   service:
-    name: "{{ monitoring_service_name }}"
+    name: stackdriver-agent
     state: restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,4 @@
   service:
     name: stackdriver-agent
     state: restarted
+  when: not ansible_check_mode

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -41,7 +41,7 @@
       force: yes
       mode: 0644
       validate: '/opt/stackdriver/collectd/sbin/stackdriver-collectd -tC %s'
-    when: main_config_file|length > 0
+    when: main_config_file
     notify: restart monitoring agent
 
   - name: Copy additional configs onto the remote machine
@@ -53,7 +53,7 @@
       validate: '/opt/stackdriver/collectd/sbin/stackdriver-collectd -tC %s'
     with_fileglob:
       - "{{ additional_config_dir }}/*.conf"
-    when: additional_config_dir|length > 0
+    when: additional_config_dir
     notify: restart monitoring agent
 
 - name: Remove temp directory

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -4,18 +4,19 @@
     that: package_state in ["present", "absent"]
     msg: "Received invalid package state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
-- name: Create directory for scripts
-  file:
-    path: /usr/local/bin/cloud_ops_scripts
-    state: directory
-    mode: 0755
+- name: Create temp directory
+    tempfile:
+      path: /tmp
+      state: directory
+    register: tempfolder
+    changed_when: false
 
 - name: Download script
-  get_url:
-    url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
-    dest: /usr/local/bin/cloud_ops_scripts/add-monitoring-agent-repo.sh
-    force: yes
-    mode: 0755
+    get_url:
+      url: https://dl.google.com/cloudagents/add-logging-agent-repo.sh
+      dest: "{{ tempfolder.path }}/add-logging-agent-repo.sh"
+      force: yes
+      mode: 0755
 
 - when: package_state == "present"
   block:
@@ -35,7 +36,7 @@
       dest: /etc/stackdriver/collectd.conf
       force: yes
       mode: 0644
-      validate: "{{ monitoring_binary }} -tC %s"
+      validate: '/opt/stackdriver/collectd/sbin/stackdriver-collectd -tC %s'
     when: main_config_file|length > 0
     notify: restart monitoring agent
 
@@ -45,7 +46,7 @@
       dest: /etc/stackdriver/collectd.d/
       force: yes
       mode: 0644
-      validate: "{{ monitoring_binary }} -tC %s"
+      validate: '/opt/stackdriver/collectd/sbin/stackdriver-collectd -tC %s'
     with_fileglob:
       - "{{ additional_config_dir }}/*.conf"
     when: additional_config_dir|length > 0
@@ -57,3 +58,9 @@
   register: result
   changed_when: "'No changes made.' not in result.stdout_lines"
   when: package_state == "absent"
+
+- name: Remove temp directory
+    file:
+      path: "{{ tempfolder.path }}"
+      state: absent
+    changed_when: false

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -50,6 +50,7 @@
     with_fileglob:
       - "{{ additional_config_dir }}/*.conf"
     when: additional_config_dir|length > 0
+    notify: restart monitoring agent
 
 - when: package_state == 'absent'
   block:

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -8,6 +8,7 @@
   tempfile:
     path: /tmp
     state: directory
+    suffix: cloud_ops_shell_scripts
   register: tempfolder
   changed_when: false
 
@@ -18,7 +19,7 @@
     mode: 0755
   changed_when: false
 
-- when: package_state == "present"
+- when: package_state == 'present'
   block:
   - name: Add repo and install agent
     command:

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -26,7 +26,7 @@
   - name: Add repo and install agent
     command:
       chdir: "{{ tempfolder.path }}"
-      cmd: "bash add-monitoring-agent-repo.sh --also-install --version={{ version }} { '--dry-run' if ansible_check_mode else '' }"
+      cmd: "bash add-monitoring-agent-repo.sh --also-install --version={{ version }} {{ '--dry-run' if ansible_check_mode else '' }}"
     environment:
       REPO_CODENAME: "{{ ansible_distribution_release }}"
     register: result
@@ -61,7 +61,7 @@
   - name: Uninstall agent and remove repo
     command:
       chdir: "{{ tempfolder.path }}"
-      cmd: "bash add-monitoring-agent-repo.sh --uninstall --remove_repo { '--dry-run' if ansible_check_mode else '' }"
+      cmd: "bash add-monitoring-agent-repo.sh --uninstall --remove_repo {{ '--dry-run' if ansible_check_mode else '' }}"
     register: result
     check_mode: no
     changed_when: "'No changes made.' not in result.stdout_lines"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -54,7 +54,7 @@
 - name: Uninstall agent and remove repo
   command:
     chdir: /usr/local/bin/cloud_ops_scripts/
-    cmd: bash add-monitoring-agent-repo.sh --uninstall
+    cmd: bash add-monitoring-agent-repo.sh --uninstall --remove_repo
   register: result
   changed_when: "'No changes made.' not in result.stdout_lines"
   when: package_state == "absent"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -21,19 +21,19 @@
   check_mode: no
   changed_when: false
 
+- name: Add repo and install agent or remove repo and uninstall agent
+  command:
+    chdir: "{{ tempfolder.path }}"
+    cmd: "bash add-monitoring-agent-repo.sh {{ '--also-install' if package_state == 'present' else '--uninstall --remove-repo' }} --version={{ version }} {{ '--dry-run' if ansible_check_mode else '' }}"
+  environment:
+    REPO_CODENAME: "{{ ansible_distribution_release }}"
+  register: result
+  check_mode: no
+  changed_when: "'No changes made.' not in result.stdout_lines"
+  notify: restart monitoring agent
+
 - when: package_state == 'present'
   block:
-  - name: Add repo and install agent
-    command:
-      chdir: "{{ tempfolder.path }}"
-      cmd: "bash add-monitoring-agent-repo.sh --also-install --version={{ version }} {{ '--dry-run' if ansible_check_mode else '' }}"
-    environment:
-      REPO_CODENAME: "{{ ansible_distribution_release }}"
-    register: result
-    check_mode: no
-    changed_when: "'No changes made.' not in result.stdout_lines"
-    notify: restart monitoring agent
-
   - name: Copy main config file onto the remote machine
     copy:
       src: "{{ main_config_file }}"
@@ -55,16 +55,6 @@
       - "{{ additional_config_dir }}/*.conf"
     when: additional_config_dir|length > 0
     notify: restart monitoring agent
-
-- when: package_state == 'absent'
-  block:
-  - name: Uninstall agent and remove repo
-    command:
-      chdir: "{{ tempfolder.path }}"
-      cmd: "bash add-monitoring-agent-repo.sh --uninstall --remove_repo {{ '--dry-run' if ansible_check_mode else '' }}"
-    register: result
-    check_mode: no
-    changed_when: "'No changes made.' not in result.stdout_lines"
 
 - name: Remove temp directory
   file:

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -13,9 +13,8 @@
 
 - name: Download script
     get_url:
-      url: https://dl.google.com/cloudagents/add-logging-agent-repo.sh
-      dest: "{{ tempfolder.path }}/add-logging-agent-repo.sh"
-      force: yes
+      url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
+      dest: "{{ tempfolder.path }}/add-monitoring-agent-repo.sh"
       mode: 0755
 
 - when: package_state == "present"
@@ -53,7 +52,7 @@
 
 - name: Uninstall agent and remove repo
   command:
-    chdir: /usr/local/bin/cloud_ops_scripts/
+    chdir: "{{ tempfolder.path }}"
     cmd: bash add-monitoring-agent-repo.sh --uninstall --remove_repo
   register: result
   changed_when: "'No changes made.' not in result.stdout_lines"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -4,24 +4,24 @@
     that: package_state in ["present", "absent"]
     msg: "Received invalid package state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
-- block:
-  - name: Create temp directory
-    tempfile:
-      path: /tmp
-      state: directory
-      suffix: cloud_ops_shell_scripts
-    register: tempfolder
+- name: Create directory for scripts
+  file:
+    path: /usr/local/bin/cloud_ops_scripts
+    state: directory
+    mode: 0755
 
-  - name: Download script
-    get_url:
-      url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
-      dest: "{{ tempfolder.path }}/add-monitoring-agent-repo.sh"
-      force: yes
-      mode: 0755
+- name: Download script
+  get_url:
+    url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
+    dest: /usr/local/bin/cloud_ops_scripts/add-monitoring-agent-repo.sh
+    force: yes
+    mode: 0755
 
+- when: package_state == "present"
+  block:
   - name: Add repo and install agent
     command:
-      chdir: "{{ tempfolder.path }}"
+      chdir: /usr/local/bin/cloud_ops_scripts/
       cmd: "bash add-monitoring-agent-repo.sh --also-install --version={{ version }}"
     environment:
       REPO_CODENAME: "{{ ansible_distribution_release }}"
@@ -29,33 +29,31 @@
     changed_when: "'No changes made.' not in result.stdout_lines"
     notify: restart monitoring agent
 
-  when: package_state == "present"
+  - name: Copy main config file onto the remote machine
+    copy:
+      src: "{{ main_config_file }}"
+      dest: /etc/stackdriver/collectd.conf
+      force: yes
+      mode: 0644
+      validate: "{{ monitoring_binary }} -tC %s"
+    when: main_config_file|length > 0
+    notify: restart monitoring agent
 
-- name: Uninstall agent
-  package:
-    name: "{{ monitoring_package_name }}"
-    state: "{{ package_state }}"
+  - name: Copy additional configs onto the remote machine
+    copy:
+      src: "{{ item }}"
+      dest: /etc/stackdriver/collectd.d/
+      force: yes
+      mode: 0644
+      validate: "{{ monitoring_binary }} -tC %s"
+    with_fileglob:
+      - "{{ additional_config_dir }}/*.conf"
+    when: additional_config_dir|length > 0
+
+- name: Uninstall agent and remove repo
+  command:
+    chdir: /usr/local/bin/cloud_ops_scripts/
+    cmd: bash add-monitoring-agent-repo.sh --uninstall
+  register: result
+  changed_when: "'No changes made.' not in result.stdout_lines"
   when: package_state == "absent"
-#TODO(rmoriar1): Clean up the repo when package_state is absent.
-
-- name: Copy main config file onto the remote machine
-  copy:
-    src: "{{ main_config_file }}"
-    dest: /etc/stackdriver/collectd.conf
-    force: yes
-    mode: 0644
-    validate: "{{ monitoring_binary }} -tC %s"
-  when: main_config_file|length > 0
-  notify: restart monitoring agent
-
-- name: Copy additional configs onto the remote machine
-  copy:
-    src: "{{ item }}"
-    dest: /etc/stackdriver/collectd.d/
-    force: yes
-    mode: 0644
-    validate: "{{ monitoring_binary }} -tC %s"
-  with_fileglob:
-    - "{{ additional_config_dir }}/*.conf"
-  when: additional_config_dir|length > 0
-  notify: restart monitoring agent

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -1,21 +1,22 @@
 ---
 - name: Validate package_state
   assert:
-    that: package_state in ["present", "absent"]
+    that: package_state in ['present', 'absent']
     msg: "Received invalid package state: '{{ package_state }}'. The Cloud Ops Ansible role supports the following package states: 'present' and 'absent'."
 
 - name: Create temp directory
-    tempfile:
-      path: /tmp
-      state: directory
-    register: tempfolder
-    changed_when: false
+  tempfile:
+    path: /tmp
+    state: directory
+  register: tempfolder
+  changed_when: false
 
 - name: Download script
-    get_url:
-      url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
-      dest: "{{ tempfolder.path }}/add-monitoring-agent-repo.sh"
-      mode: 0755
+  get_url:
+    url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
+    dest: "{{ tempfolder.path }}/add-monitoring-agent-repo.sh"
+    mode: 0755
+  changed_when: false
 
 - when: package_state == "present"
   block:
@@ -50,16 +51,17 @@
       - "{{ additional_config_dir }}/*.conf"
     when: additional_config_dir|length > 0
 
-- name: Uninstall agent and remove repo
-  command:
-    chdir: "{{ tempfolder.path }}"
-    cmd: bash add-monitoring-agent-repo.sh --uninstall --remove_repo
-  register: result
-  changed_when: "'No changes made.' not in result.stdout_lines"
-  when: package_state == "absent"
+- when: package_state == 'absent'
+  block:
+  - name: Uninstall agent and remove repo
+    command:
+      chdir: "{{ tempfolder.path }}"
+      cmd: bash add-monitoring-agent-repo.sh --uninstall --remove_repo
+    register: result
+    changed_when: "'No changes made.' not in result.stdout_lines"
 
 - name: Remove temp directory
-    file:
-      path: "{{ tempfolder.path }}"
-      state: absent
-    changed_when: false
+  file:
+    path: "{{ tempfolder.path }}"
+    state: absent
+  changed_when: false

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -22,7 +22,7 @@
   block:
   - name: Add repo and install agent
     command:
-      chdir: /usr/local/bin/cloud_ops_scripts/
+      chdir: "{{ tempfolder.path }}"
       cmd: "bash add-monitoring-agent-repo.sh --also-install --version={{ version }}"
     environment:
       REPO_CODENAME: "{{ ansible_distribution_release }}"

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -10,6 +10,7 @@
     state: directory
     suffix: cloud_ops_shell_scripts
   register: tempfolder
+  check_mode: no
   changed_when: false
 
 - name: Download script
@@ -17,6 +18,7 @@
     url: https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
     dest: "{{ tempfolder.path }}/add-monitoring-agent-repo.sh"
     mode: 0755
+  check_mode: no
   changed_when: false
 
 - when: package_state == 'present'
@@ -24,10 +26,11 @@
   - name: Add repo and install agent
     command:
       chdir: "{{ tempfolder.path }}"
-      cmd: "bash add-monitoring-agent-repo.sh --also-install --version={{ version }}"
+      cmd: "bash add-monitoring-agent-repo.sh --also-install --version={{ version }} { '--dry-run' if ansible_check_mode else '' }"
     environment:
       REPO_CODENAME: "{{ ansible_distribution_release }}"
     register: result
+    check_mode: no
     changed_when: "'No changes made.' not in result.stdout_lines"
     notify: restart monitoring agent
 
@@ -58,12 +61,14 @@
   - name: Uninstall agent and remove repo
     command:
       chdir: "{{ tempfolder.path }}"
-      cmd: bash add-monitoring-agent-repo.sh --uninstall --remove_repo
+      cmd: "bash add-monitoring-agent-repo.sh --uninstall --remove_repo { '--dry-run' if ansible_check_mode else '' }"
     register: result
+    check_mode: no
     changed_when: "'No changes made.' not in result.stdout_lines"
 
 - name: Remove temp directory
   file:
     path: "{{ tempfolder.path }}"
     state: absent
+  check_mode: no
   changed_when: false


### PR DESCRIPTION
Hard-code monitoring binary path, package name and service name. Unconditionally download the shell script and uninstall via the script if `package_state == "absent"` rather that using the `package` module. Clean up the temp directory at the end of the play.

Add support for check_mode by conditionally running the script with the `--dry-run` flag.

Do not submit until cl/355032607 and cl/356353951 are merged and released. 